### PR TITLE
Fixed Delete button color of delete tags for color consistency across…

### DIFF
--- a/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/home/TagSelectionBottomSheet.kt
+++ b/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/home/TagSelectionBottomSheet.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.HorizontalDivider
@@ -25,6 +24,7 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
@@ -170,12 +170,12 @@ fun TagSelectionBottomSheet(
                             .makeText(context, context.getString(R.string.tag_deleted_successfully), Toast.LENGTH_SHORT)
                             .show()
                     }
-                }, colors = ButtonDefaults.buttonColors(containerColor = Color.Red)) {
+                }) {
                     Text(stringResource(R.string.delete))
                 }
             },
             dismissButton = {
-                Button(onClick = {
+                OutlinedButton(onClick = {
                     isTagDeleteEnable = null
                 }) {
                     Text(stringResource(R.string.cancel))


### PR DESCRIPTION
This PR contains the following work done: 
- Fix the color of delete tags and followed the delete link dialog button colors for consistency throughout the application previously one button was accent and one was red 
- Tested the delete and cancel functionality also after changing button colors

<img width="35%" height="2424" alt="Screenshot_20251009_235428" src="https://github.com/user-attachments/assets/2c241d55-23b9-4936-91f4-519e27637c7d" />

fixes #164 
