### PR TITLE
fix: notes text color in dark mode (#372)

### DIFF
--- a/app/src/main/java/com/yogeshpaliyal/deepr/ui/components/NoteViewDialog.kt
+++ b/app/src/main/java/com/yogeshpaliyal/deepr/ui/components/NoteViewDialog.kt
@@ -90,6 +90,7 @@ fun NoteViewDialog(
                 SelectionContainer {
                     ClickableText(
                         text = annotatedString,
+                        style = MaterialTheme.typography.bodyLarge.copy(color = MaterialTheme.colorScheme.onSurface),
                         onClick = { offset ->
                             // Check if clicked position has a URL annotation
                             annotatedString


### PR DESCRIPTION
Fixes issue #372 by setting an explicit onSurface text color for notes in the View Dialog, ensuring readability regardless of the theme.