### PR TITLE
fix: show tags even if they have no links in the current profile (#358)

### DIFF
--- a/app/src/main/sqldelight/com/yogeshpaliyal/deepr/Deepr.sq
+++ b/app/src/main/sqldelight/com/yogeshpaliyal/deepr/Deepr.sq
@@ -215,7 +215,7 @@ FROM Tags
 LEFT JOIN LinkTags ON Tags.id = LinkTags.tagId
 LEFT JOIN Deepr ON LinkTags.linkId = Deepr.id
 GROUP BY Tags.id, Tags.name
-HAVING linkCount > 0
+
 ORDER BY linkCount DESC, Tags.name;
 
 countOfLinks:


### PR DESCRIPTION
Fixes issue #358 by removing the filter that hid tags with zero links in the current profile. Now, tags created from the Tags screen or tags that become empty after deleting links will remain visible and manageable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tags without linked entries are now included in results
  * Updated tag sorting to prioritize by frequency, then alphabetically

<!-- end of auto-generated comment: release notes by coderabbit.ai -->