### PR TITLE
feat: make link name optional on local server (#199)

### DIFF
--- a/app/src/main/assets/index.html
+++ b/app/src/main/assets/index.html
@@ -119,13 +119,13 @@
 
                     <div class="flex-1">
                         <label for="linkName" class="block text-sm font-medium text-gray-700 mb-2">
-                            Link Name
+                            Link Name (Optional)
                         </label>
                         <input
                             type="text"
                             id="linkName"
-                            placeholder="My Awesome Link"
-                            required
+                            placeholder="My Awesome Link (Optional)"
+                            
                             class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-2 focus:ring-primary-500 focus:border-transparent transition-all duration-200 text-gray-800"
                         >
                     </div>


### PR DESCRIPTION
This PR makes the link name field optional in the local server web interface, matching the behavior of the mobile app where the name is also optional.