### PR TITLE
fix: set 'system default' as default for language and theme (#382)

### DIFF
--- a/app/src/main/java/com/yogeshpaliyal/deepr/preference/AppPreferenceDataStore.kt
+++ b/app/src/main/java/com/yogeshpaliyal/deepr/preference/AppPreferenceDataStore.kt
@@ -112,7 +112,7 @@ class AppPreferenceDataStore(
 
     val getThemeMode: Flow<String> =
         context.appDataStore.data.map { preferences ->
-            preferences[THEME_MODE] ?: "light" // Default to light theme
+            preferences[THEME_MODE] ?: "system" // Default to system theme
         }
 
     val getShowOpenCounter: Flow<Boolean> =

--- a/app/src/main/java/com/yogeshpaliyal/deepr/ui/components/ThemeSelectionDialog.kt
+++ b/app/src/main/java/com/yogeshpaliyal/deepr/ui/components/ThemeSelectionDialog.kt
@@ -13,7 +13,9 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.yogeshpaliyal.deepr.R
 
 @Composable
 fun ThemeSelectionDialog(
@@ -23,16 +25,16 @@ fun ThemeSelectionDialog(
 ) {
     val themeOptions =
         listOf(
-            "system" to "System default",
-            "light" to "Light",
-            "dark" to "Dark",
+            "system" to stringResource(R.string.system_default),
+            "light" to stringResource(R.string.theme_light),
+            "dark" to stringResource(R.string.theme_dark),
         )
 
     AlertDialog(
         onDismissRequest = onDismiss,
         title = {
             Text(
-                text = "Select Theme",
+                text = stringResource(R.string.theme_dialog_title),
                 style = MaterialTheme.typography.headlineSmall,
             )
         },
@@ -62,7 +64,7 @@ fun ThemeSelectionDialog(
         },
         confirmButton = {
             TextButton(onClick = onDismiss) {
-                Text("Close")
+                Text(stringResource(R.string.close))
             }
         },
     )

--- a/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/Settings.kt
+++ b/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/Settings.kt
@@ -235,12 +235,12 @@ fun SettingsScreen(
 
                 SettingsItem(
                     TablerIcons.Moon,
-                    title = "Theme",
+                    title = stringResource(R.string.theme),
                     description =
                         when (themeMode) {
-                            "light" -> "Light"
-                            "dark" -> "Dark"
-                            else -> "System default"
+                            "light" -> stringResource(R.string.theme_light)
+                            "dark" -> stringResource(R.string.theme_dark)
+                            else -> stringResource(R.string.system_default)
                         },
                     onClick = {
                         showThemeDialog = true

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -101,4 +101,10 @@
     <string name="shortcut_icon">Icona di scorciatoia</string>
     <string name="use_link_app_icon">Utilizzare l\'icona dell\'app di supporto del link</string>
     <string name="use_deepr_app_icon">Usa l\'icona dell\'app Deepr</string>
+    <string name="theme">Tema</string>
+    <string name="system_default">Predefinito di Sistema</string>
+    <string name="theme_dialog_title">Seleziona Tema</string>
+    <string name="theme_light">Chiaro</string>
+    <string name="theme_dark">Scuro</string>
+    <string name="close">Chiudi</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -114,6 +114,7 @@
     <string name="language">Language</string>
     <string name="language_description">Change app language</string>
     <string name="language_dialog_title">Select Language</string>
+    <string name="theme">Theme</string>
     <string name="system_default">System Default</string>
     <string name="english">English</string>
     <string name="hindi">हिंदी</string>
@@ -281,4 +282,8 @@
     <!-- Clipboard Link Detection Setting -->
     <string name="clipboard_link_detection">Clipboard link detection</string>
     <string name="clipboard_link_detection_description">Automatically detect links in clipboard and show a banner to add them</string>
+    <string name="theme_dialog_title">Select Theme</string>
+    <string name="theme_light">Light</string>
+    <string name="theme_dark">Dark</string>
+    <string name="close">Close</string>
 </resources>


### PR DESCRIPTION
This PR sets 'System Default' as the default option for both language and theme settings. It also localizes the theme selection strings.