### PR TITLE
1: Fix SQLite foreign key constraints at connection opening

### DIFF
--- a/app/src/main/java/com/yogeshpaliyal/deepr/DeeprApplication.kt
+++ b/app/src/main/java/com/yogeshpaliyal/deepr/DeeprApplication.kt
@@ -50,9 +50,15 @@ class DeeprApplication : Application() {
                 single<SqlDriver> {
                     LogSqliteDriver(
                         AndroidSqliteDriver(
-                            DeeprDB.Schema,
-                            this@DeeprApplication,
-                            "deepr.db",
+                            schema = DeeprDB.Schema,
+                            context = this@DeeprApplication,
+                            name = "deepr.db",
+                            callback = object : AndroidSqliteDriver.Callback(DeeprDB.Schema) {
+                                override fun onOpen(db: androidx.sqlite.db.SupportSQLiteDatabase) {
+                                    super.onOpen(db)
+                                    db.setForeignKeyConstraintsEnabled(true)
+                                }
+                            },
                         ),
                     ) {
                         Log.d("loggingDB", it)


### PR DESCRIPTION
This PR enables SQLite Foreign Key constraints at connection opening in DeeprApplication. Part 1 of 10 in the sequential merge.