### PR TITLE
Fix: Improve QR code contrast and accessibility in dark mode

### DIFF
--- a/app/src/main/java/com/yogeshpaliyal/deepr/ui/components/QRCodeDialog.kt
+++ b/app/src/main/java/com/yogeshpaliyal/deepr/ui/components/QRCodeDialog.kt
@@ -6,12 +6,12 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.AlertDialogDefaults
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -20,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.lightspark.composeqr.DotShape
 import com.lightspark.composeqr.QrCodeColors
@@ -34,37 +35,49 @@ fun QrCodeDialog(
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("QR Code") },
+        title = { Text(stringResource(R.string.show_qr_code)) },
         text = {
-            Column {
-                QrCodeView(
-                    data = deepr.link,
-                    modifier = Modifier.size(300.dp),
-                    colors =
-                        QrCodeColors(
-                            background = AlertDialogDefaults.containerColor,
-                            foreground = MaterialTheme.colorScheme.onSurface,
-                        ),
-                    dotShape = DotShape.Circle,
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Box(
+                    modifier =
+                        Modifier
+                            .background(
+                                color = Color.White,
+                                shape = RoundedCornerShape(12.dp),
+                            ).padding(16.dp),
                 ) {
-                    Box(
-                        contentAlignment = Alignment.Center,
-                        modifier =
-                            Modifier
-                                .fillMaxSize()
-                                .aspectRatio(1f)
-                                .clip(RoundedCornerShape(8.dp))
-                                .background(Color.Transparent),
+                    QrCodeView(
+                        data = deepr.link,
+                        modifier = Modifier.size(268.dp),
+                        colors =
+                            QrCodeColors(
+                                background = Color.White,
+                                foreground = Color.Black,
+                            ),
+                        dotShape = DotShape.Circle,
                     ) {
-                        Image(
-                            painter = painterResource(id = R.drawable.app_logo),
-                            contentDescription = "App Logo",
+                        Box(
+                            contentAlignment = Alignment.Center,
                             modifier =
                                 Modifier
-                                    .fillMaxSize(0.5f)
-                                    .clip(CircleShape)
-                                    .background(Color.White),
-                        )
+                                    .fillMaxSize()
+                                    .aspectRatio(1f)
+                                    .clip(RoundedCornerShape(8.dp))
+                                    .background(Color.Transparent),
+                        ) {
+                            Image(
+                                painter = painterResource(id = R.drawable.app_logo),
+                                contentDescription = stringResource(R.string.app_logo),
+                                modifier =
+                                    Modifier
+                                        .fillMaxSize(0.5f)
+                                        .clip(CircleShape)
+                                        .background(Color.White),
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/LocalNetworkServer.kt
+++ b/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/LocalNetworkServer.kt
@@ -42,6 +42,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -228,13 +229,18 @@ fun LocalNetworkServerScreen(
                                 modifier =
                                     Modifier
                                         .background(
-                                            MaterialTheme.colorScheme.surface,
+                                            Color.White,
                                             RoundedCornerShape(12.dp),
                                         ).padding(16.dp),
                             ) {
                                 QrCodeView(
                                     data = serverUrl ?: "",
                                     modifier = Modifier.size(180.dp),
+                                    colors =
+                                        com.lightspark.composeqr.QrCodeColors(
+                                            background = Color.White,
+                                            foreground = Color.Black,
+                                        ),
                                 )
                             }
                         }

--- a/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/TransferLinkLocalServer.kt
+++ b/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/TransferLinkLocalServer.kt
@@ -10,6 +10,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -42,6 +43,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
@@ -316,10 +318,24 @@ fun TransferLinkLocalServerScreen(
                                 textAlign = TextAlign.Center,
                             )
                             Spacer(modifier = Modifier.height(8.dp))
-                            QrCodeView(
-                                data = qrCodeData ?: "",
-                                modifier = Modifier.size(200.dp),
-                            )
+                            Box(
+                                modifier =
+                                    Modifier
+                                        .background(
+                                            Color.White,
+                                            RoundedCornerShape(12.dp),
+                                        ).padding(16.dp),
+                            ) {
+                                QrCodeView(
+                                    data = qrCodeData ?: "",
+                                    modifier = Modifier.size(200.dp),
+                                    colors =
+                                        com.lightspark.composeqr.QrCodeColors(
+                                            background = Color.White,
+                                            foreground = Color.Black,
+                                        ),
+                                )
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This PR improves the accessibility and scanability of QR codes, particularly when the system is in Dark Mode.

### Changes
- **QR Code Contrast**: Refactored the QrCodeView in both QRCodeDialog and TransferLinkLocalServer to enforce a white background and a black foreground.
- Added a rounded white container around the QR codes.
- This ensures that QR codes remain easily scannable on all devices regardless of the active theme.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved QR code visual presentation across screens with consistent white backgrounds and black foreground coloring
  * Enhanced QR code layout with better padding and rounded corner styling
  * Replaced hardcoded text with string resources for improved maintainability

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yogeshpaliyal/Deepr/pull/433)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->