### PR TITLE
Docs: Reorder build variants table and download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ You can download from any of the sources mentioned below.
 All these sources supports cross platform app updates. for eg: if you've installed app from F-Droid
 then you can update the app from any of the sources.
 
-- Github Release : [Download](https://github.com/yogeshpaliyal/Deepr/releases/latest)
+- GitHub Release : [Download](https://github.com/yogeshpaliyal/Deepr/releases/latest)
 - F-Droid : [Download](https://f-droid.org/packages/com.yogeshpaliyal.deepr/)
 - Play Store: [Download](https://play.google.com/store/apps/details?id=com.yogeshpaliyal.deepr)
 - Play Store (All features unlocked) : [Download](https://play.google.com/store/apps/details?id=com.yogeshpaliyal.deepr.pro)

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@
 
 ### Build Variant specific features
 
-| Feature                           | Github Release | Play Store | F-droid | Pro Version on Play Store |
-|-----------------------------------|----------------|------------|---------|-----------|
-| Firebase Analytics                | ❌              | ✅          | ❌       | ✅  |
-| Google Drive Backup | ❌              | ❌         | ❌       | ✅  |
-| Profile speicific themes | ❌              | ❌          | ❌       | ✅  |
+| Feature                           | Github Release | F-droid | Play Store | Pro Version on Play Store |
+|-----------------------------------|----------------|---------|------------|-----------|
+| Firebase Analytics                | ❌              | ❌       | ✅          | ✅  |
+| Google Drive Backup | ❌              | ❌       | ❌         | ✅  |
+| Profile speicific themes | ❌              | ❌       | ❌          | ✅  |
 
 
 
@@ -58,11 +58,10 @@ You can download from any of the sources mentioned below.
 All these sources supports cross platform app updates. for eg: if you've installed app from F-Droid
 then you can update the app from any of the sources.
 
-- F-Droid : [Download](https://f-droid.org/packages/com.yogeshpaliyal.deepr/)
 - Github Release : [Download](https://github.com/yogeshpaliyal/Deepr/releases/latest)
+- F-Droid : [Download](https://f-droid.org/packages/com.yogeshpaliyal.deepr/)
 - Play Store: [Download](https://play.google.com/store/apps/details?id=com.yogeshpaliyal.deepr)
-- Play Store (All features
-  unlocked) : [Download](https://play.google.com/store/apps/details?id=com.yogeshpaliyal.deepr.pro)
+- Play Store (All features unlocked) : [Download](https://play.google.com/store/apps/details?id=com.yogeshpaliyal.deepr.pro)
 
 
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 |-----------------------------------|----------------|---------|------------|-----------|
 | Firebase Analytics                | ❌              | ❌       | ✅          | ✅  |
 | Google Drive Backup | ❌              | ❌       | ❌         | ✅  |
-| Profile speicific themes | ❌              | ❌       | ❌          | ✅  |
+| Profile specific themes | ❌              | ❌       | ❌          | ✅  |
 
 
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 ### Build Variant specific features
 
-| Feature                           | Github Release | F-droid | Play Store | Pro Version on Play Store |
+| Feature                           | GitHub Release | F-droid | Play Store | Pro Version on Play Store |
 |-----------------------------------|----------------|---------|------------|-----------|
 | Firebase Analytics                | ❌              | ❌       | ✅          | ✅  |
 | Google Drive Backup | ❌              | ❌       | ❌         | ✅  |

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > Deepr is a native Android application designed to streamline the management and testing of links.
 > It provides a simple and efficient way to store, organize, and open links.
 
-[![Github Releases](https://img.shields.io/github/v/release/yogeshpaliyal/Deepr?style=for-the-badge)](https://github.com/yogeshpaliyal/Deepr/releases/latest)
+[![GitHub Releases](https://img.shields.io/github/v/release/yogeshpaliyal/Deepr?style=for-the-badge)](https://github.com/yogeshpaliyal/Deepr/releases/latest)
 [![Latest Master](https://img.shields.io/badge/Master-master?color=7885FF&label=Build&logo=android&style=for-the-badge)](https://github.com/yogeshpaliyal/Deepr/releases/download/latest-master/app-debug.apk)
 [![Android Weekly](https://img.shields.io/badge/Android%20Weekly-%23685-2CA3E6.svg?style=for-the-badge)](http://androidweekly.net/issues/issue-685)    
 


### PR DESCRIPTION
This PR contains minor documentation improvements.

### Changes
- Reordered the Build Variant specific features table to align F-Droid before Play Store.
- Reordered the Download links list to prioritize the Github Release and F-Droid over the Play Store links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Capitalized README badge text to “GitHub Releases”.
  * Reordered columns in the build-variant features table so Play Store sits alongside F‑Droid before the Pro column.
  * Corrected spelling for the profile-specific themes row; feature markers remain unchanged.
  * Reordered download links to show GitHub Release first, then F‑Droid, then Play Store, and consolidated the Play Store link onto one line.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yogeshpaliyal/Deepr/pull/436)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->