### PR TITLE
Feature: Pre-populate current profile when adding a new link

### DIFF
--- a/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/addlink/AddLinkScreen.kt
+++ b/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/addlink/AddLinkScreen.kt
@@ -134,9 +134,19 @@ fun AddLinkScreen(
 
     // Profile selection
     val allProfiles by viewModel.allProfiles.collectAsStateWithLifecycle()
+    val currentProfile by viewModel.currentProfile.collectAsStateWithLifecycle()
     var selectedProfileId by remember(selectedLink) {
         mutableStateOf(selectedLink.profileId)
     }
+
+    // Pre-populate with current profile if it's a new link and we are currently at default
+    // This handles cases where the current profile might take a moment to load
+    LaunchedEffect(currentProfile) {
+        if (isCreate && selectedProfileId == 1L && currentProfile != null) {
+            selectedProfileId = currentProfile!!.id
+        }
+    }
+
     var showCreateProfileDialog by remember { mutableStateOf(false) }
     var pendingProfileNameToSelect by remember { mutableStateOf<String?>(null) }
 


### PR DESCRIPTION
This PR ensures that when a user adds a new link, the profile field is pre-populated with the currently active profile. 

- Modified 'AddLinkScreen' to observe 'currentProfile' from 'AccountViewModel'.
- Implemented logic to sync 'selectedProfileId' with the current profile for new links.
- Handles race conditions where the current profile might still be loading when the screen opens.