### PR TITLE
Fix #397: Improve title fetching for Reddit and Silent Save

### DIFF
--- a/app/src/main/java/com/yogeshpaliyal/deepr/SilentSaveActivity.kt
+++ b/app/src/main/java/com/yogeshpaliyal/deepr/SilentSaveActivity.kt
@@ -8,6 +8,7 @@ import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.lifecycle.lifecycleScope
 import com.yogeshpaliyal.deepr.data.LinkRepository
+import com.yogeshpaliyal.deepr.data.NetworkRepository
 import com.yogeshpaliyal.deepr.preference.AppPreferenceDataStore
 import com.yogeshpaliyal.deepr.util.isValidDeeplink
 import com.yogeshpaliyal.deepr.util.normalizeLink
@@ -24,6 +25,7 @@ import org.koin.android.ext.android.inject
  */
 class SilentSaveActivity : ComponentActivity() {
     private val linkRepository: LinkRepository by inject()
+    private val networkRepository: NetworkRepository by inject()
     private val preferenceDataStore: AppPreferenceDataStore by inject()
     private val deeprQueries: DeeprQueries by inject()
 
@@ -43,6 +45,9 @@ class SilentSaveActivity : ComponentActivity() {
         handleSharedLink(intent, appContext)
     }
 
+    /**
+     * Processes the incoming share intent.
+     */
     private fun handleSharedLink(
         intent: Intent,
         appContext: Context,
@@ -64,6 +69,9 @@ class SilentSaveActivity : ComponentActivity() {
         }
     }
 
+    /**
+     * Saves the link to the database, fetching metadata if title or thumbnail is missing.
+     */
     private fun saveLinkSilently(
         link: String,
         title: String,
@@ -84,12 +92,27 @@ class SilentSaveActivity : ComponentActivity() {
                     return@launch
                 }
 
+                var finalTitle = title
+                var finalThumbnail = ""
+
+                // If title or thumbnail is blank, try to fetch it
+                if (finalTitle.isBlank() || finalThumbnail.isBlank()) {
+                    networkRepository.getLinkInfo(link).onSuccess { linkInfo ->
+                        if (finalTitle.isBlank()) {
+                            finalTitle = linkInfo.title ?: ""
+                        }
+                        if (finalThumbnail.isBlank()) {
+                            finalThumbnail = linkInfo.image ?: ""
+                        }
+                    }
+                }
+
                 linkRepository.insertDeepr(
                     link = link,
-                    name = title,
+                    name = finalTitle,
                     openedCount = 0,
                     notes = "",
-                    thumbnail = "",
+                    thumbnail = finalThumbnail,
                     profileId = profileId,
                 )
 
@@ -101,6 +124,9 @@ class SilentSaveActivity : ComponentActivity() {
         }
     }
 
+    /**
+     * Helper to show toast messages and finish the activity.
+     */
     private fun showToast(
         context: Context,
         message: String,

--- a/app/src/main/java/com/yogeshpaliyal/deepr/data/HtmlParser.kt
+++ b/app/src/main/java/com/yogeshpaliyal/deepr/data/HtmlParser.kt
@@ -3,8 +3,13 @@ package com.yogeshpaliyal.deepr.data
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 
+/**
+ * Parser for extracting metadata (title, description, image) from HTML content.
+ */
 class HtmlParser {
-    // Get Open Graph content (og:title, og:image)
+    /**
+     * Extracts content from a meta tag based on property or name attributes.
+     */
     private fun getOgContent(
         doc: Document,
         property: String,
@@ -14,27 +19,42 @@ class HtmlParser {
             ?: doc.selectFirst("meta[name=$property]")?.attr("content")
     }
 
-    // Get title and image from Open Graph, or fallback as described
-    fun getTitleAndImageFromHtml(html: String): LinkInfo {
-        val doc = Jsoup.parse(html)
+    /**
+     * Extracts LinkInfo from HTML string.
+     * Prioritizes <title> and OpenGraph tags, cleaning up platform-specific clutter.
+     */
+    fun getTitleAndImageFromHtml(
+        html: String,
+        url: String? = null,
+    ): LinkInfo {
+        val doc = if (url != null) Jsoup.parse(html, url) else Jsoup.parse(html)
 
-        // 1. Try og:title and og:image from <meta>
-        val ogTitle = getOgContent(doc, "og:title")
-        val ogDescription = getOgContent(doc, "og:description")
-        val ogImage = getOgContent(doc, "og:image")
+        // 1. Try <title> first (often cleaner on Reddit/social)
+        val rawDocTitle = doc.title().takeIf { it.isNotBlank() }
+        val docTitle = rawDocTitle?.let { cleanTitle(it) }?.takeIf { it.isNotBlank() }
 
-        // 2. Fallback for title: biggest heading in document
-        val headingTags = listOf("h1", "h2", "h3", "h4", "h5", "h6")
-        val fallbackTitle =
-            if (ogTitle.isNullOrBlank()) {
+        // 2. Try og:title and twitter:title from <meta>
+        val ogTitle =
+            (getOgContent(doc, "og:title") ?: getOgContent(doc, "twitter:title"))
+                ?.let { cleanTitle(it) }
+                ?.takeIf { it.isNotBlank() }
+
+        val ogDescription =
+            getOgContent(doc, "og:description")
+                ?: getOgContent(doc, "twitter:description")
+                ?: getOgContent(doc, "description")
+        val ogImage = getOgContent(doc, "og:image") ?: getOgContent(doc, "twitter:image")
+
+        // 3. Final choice for title
+        val title =
+            docTitle ?: ogTitle ?: run {
+                val headingTags = listOf("h1", "h2", "h3", "h4", "h5", "h6")
                 headingTags.firstNotNullOfOrNull { tag ->
                     doc.selectFirst(tag)?.text()?.takeIf { it.isNotBlank() }
                 }
-            } else {
-                ogTitle
             }
 
-        // 3. Fallback for image: first img in document
+        // 4. Fallback for image: first img in document
         val fallbackImage =
             if (ogImage.isNullOrBlank()) {
                 doc.selectFirst("img")?.absUrl("src")?.takeIf { it.isNotBlank() }
@@ -42,10 +62,35 @@ class HtmlParser {
                 ogImage
             }
 
-        return LinkInfo(fallbackTitle, ogDescription, fallbackImage)
+        return LinkInfo(title, ogDescription, fallbackImage)
+    }
+
+    /**
+     * Removes platform-specific prefixes and suffixes (like Reddit community names)
+     * to provide a cleaner title.
+     */
+    private fun cleanTitle(title: String): String {
+        val prefixes = listOf("From the Android community on Reddit: ", "From the community on Reddit: ")
+        var cleaned = title
+        for (prefix in prefixes) {
+            if (cleaned.startsWith(prefix, ignoreCase = true)) {
+                cleaned = cleaned.substring(prefix.length)
+            }
+        }
+
+        val suffixes = listOf(" : r/Android", " : Reddit", " - Reddit", " | Reddit")
+        for (suffix in suffixes) {
+            if (cleaned.endsWith(suffix, ignoreCase = true)) {
+                cleaned = cleaned.substring(0, cleaned.length - suffix.length)
+            }
+        }
+        return cleaned.trim()
     }
 }
 
+/**
+ * Data class representing extracted link metadata.
+ */
 data class LinkInfo(
     val title: String?,
     val description: String?,

--- a/app/src/main/java/com/yogeshpaliyal/deepr/data/NetworkRepository.kt
+++ b/app/src/main/java/com/yogeshpaliyal/deepr/data/NetworkRepository.kt
@@ -4,26 +4,34 @@ import com.yogeshpaliyal.deepr.util.normalizeLink
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.request.get
+import io.ktor.client.request.header
 import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
 
 class NetworkRepository(
     val httpParser: HtmlParser,
+    private val httpClient: HttpClient = HttpClient(CIO),
 ) {
-    val httpClient: HttpClient by lazy {
-        HttpClient(CIO)
-    }
-
     suspend fun getLinkInfo(url: String): Result<LinkInfo> {
         val normalizedUrl = normalizeLink(url)
         try {
             val response =
                 httpClient.get(normalizedUrl) {
+                    header(
+                        HttpHeaders.UserAgent,
+                        "facebookexternalhit/1.1",
+                    )
                 }
             if (response.status.value != 200) {
                 return Result.failure(Exception("Failed to fetch data from $normalizedUrl, status code: ${response.status.value}"))
             }
             // Return the response body as text
-            return Result.success(httpParser.getTitleAndImageFromHtml(response.bodyAsText()))
+            return Result.success(
+                httpParser.getTitleAndImageFromHtml(
+                    response.bodyAsText(),
+                    normalizedUrl,
+                ),
+            )
         } catch (e: Exception) {
             return Result.failure(
                 Exception(

--- a/app/src/test/java/com/yogeshpaliyal/deepr/data/NetworkRepositoryTest.kt
+++ b/app/src/test/java/com/yogeshpaliyal/deepr/data/NetworkRepositoryTest.kt
@@ -3,7 +3,6 @@ package com.yogeshpaliyal.deepr.data
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
-import io.ktor.client.plugins.UserAgent
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import kotlinx.coroutines.test.runTest
@@ -46,7 +45,7 @@ class NetworkRepositoryTest {
 
             val httpClient = HttpClient(mockEngine)
             val htmlParser = HtmlParser()
-            val repository = NetworkRepository(httpClient, htmlParser)
+            val repository = NetworkRepository(htmlParser, httpClient)
 
             // Test with URL without https://
             val result = repository.getLinkInfo("example.com")
@@ -72,7 +71,7 @@ class NetworkRepositoryTest {
 
             val httpClient = HttpClient(mockEngine)
             val htmlParser = HtmlParser()
-            val repository = NetworkRepository(httpClient, htmlParser)
+            val repository = NetworkRepository(htmlParser, httpClient)
 
             // Test with URL that already has https://
             val result = repository.getLinkInfo("https://example.com")
@@ -98,7 +97,7 @@ class NetworkRepositoryTest {
 
             val httpClient = HttpClient(mockEngine)
             val htmlParser = HtmlParser()
-            val repository = NetworkRepository(httpClient, htmlParser)
+            val repository = NetworkRepository(htmlParser, httpClient)
 
             // Test with URL without https:// but with path
             val result = repository.getLinkInfo("example.com/path")
@@ -122,7 +121,7 @@ class NetworkRepositoryTest {
 
             val httpClient = HttpClient(mockEngine)
             val htmlParser = HtmlParser()
-            val repository = NetworkRepository(httpClient, htmlParser)
+            val repository = NetworkRepository(htmlParser, httpClient)
 
             val result = repository.getLinkInfo("example.com")
 
@@ -144,7 +143,7 @@ class NetworkRepositoryTest {
 
             val httpClient = HttpClient(mockEngine)
             val htmlParser = HtmlParser()
-            val repository = NetworkRepository(httpClient, htmlParser)
+            val repository = NetworkRepository(htmlParser, httpClient)
 
             val result = repository.getLinkInfo("example.com")
 
@@ -169,22 +168,16 @@ class NetworkRepositoryTest {
                     )
                 }
 
-            val httpClient =
-                HttpClient(mockEngine) {
-                    install(UserAgent) {
-                        agent =
-                            "Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36"
-                    }
-                }
+            val httpClient = HttpClient(mockEngine)
             val htmlParser = HtmlParser()
-            val repository = NetworkRepository(httpClient, htmlParser)
+            val repository = NetworkRepository(htmlParser, httpClient)
 
             val result = repository.getLinkInfo("example.com")
 
             // Verify the User-Agent header was sent
             assertTrue(result.isSuccess)
             assertEquals(
-                "Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36",
+                "facebookexternalhit/1.1",
                 receivedUserAgent,
             )
         }


### PR DESCRIPTION
This PR improves the title fetching logic to handle websites like Reddit that block standard bots and provides cleaner titles. It also enables metadata fetching for Silent Save activity.

Key Changes:
- **HtmlParser**: Prioritize standard `<title>` tag for cleaner titles, added support for Twitter Cards, and implemented a cleaning function to strip common Reddit prefixes/suffixes (e.g., 'From the community on Reddit').
- **NetworkRepository**: Configured a social media crawler User-Agent (`facebookexternalhit/1.1`) to bypass bot detection on sites like Reddit/Instagram.
- **SilentSaveActivity**: Now fetches metadata (title and thumbnail) if **either** is missing from the share intent, ensuring links saved silently are complete and have proper names.
- **Documentation & Standards**: Added KDocs to all modified functions and applied ktlint formatting.

This PR is rebased directly on the latest upstream master (via YOGESH branch) to include only the relevant changes.