### PR TITLE
Fix: Perfect swipe UX by blocking accidental micro-flicks (#290)

### DIFF
--- a/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/home/DeeprItemSwipable.kt
+++ b/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/home/DeeprItemSwipable.kt
@@ -52,7 +52,9 @@ fun DeeprItemSwipable(
                             } catch (e: Exception) {
                                 0f
                             }
-                        offset >= (itemWidth * 0.35f)
+                        // Block accidental micro-flicks (e.g. from vertical scrolling)
+                        // but allow intentional fast flings once they cross 20% of the item.
+                        offset >= (itemWidth * 0.20f)
                     } else {
                         false
                     }

--- a/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/home/DeeprItemSwipable.kt
+++ b/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/home/DeeprItemSwipable.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -37,7 +38,7 @@ fun DeeprItemSwipable(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
-    var itemWidth by remember { mutableStateOf(0) }
+    var itemWidth by remember { mutableIntStateOf(0) }
     val dismissStateHolder = remember { mutableStateOf<androidx.compose.material3.SwipeToDismissBoxState?>(null) }
     val dismissState =
         rememberSwipeToDismissBoxState(

--- a/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/home/DeeprItemSwipable.kt
+++ b/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/home/DeeprItemSwipable.kt
@@ -10,13 +10,16 @@ import androidx.compose.material3.SwipeToDismissBox
 import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.yogeshpaliyal.deepr.GetLinksAndTags
@@ -25,6 +28,7 @@ import compose.icons.TablerIcons
 import compose.icons.tablericons.Edit
 import compose.icons.tablericons.Trash
 import kotlinx.coroutines.launch
+import kotlin.math.abs
 
 @Composable
 fun DeeprItemSwipable(
@@ -33,14 +37,25 @@ fun DeeprItemSwipable(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
+    var itemWidth by remember { mutableStateOf(0) }
     val dismissStateHolder = remember { mutableStateOf<androidx.compose.material3.SwipeToDismissBoxState?>(null) }
     val dismissState =
         rememberSwipeToDismissBoxState(
             initialValue = SwipeToDismissBoxValue.Settled,
             confirmValueChange = { newValue ->
                 if (newValue != SwipeToDismissBoxValue.Settled) {
-                    val progress = dismissStateHolder.value?.progress ?: 0f
-                    progress >= 0.35f
+                    val state = dismissStateHolder.value
+                    if (state != null && itemWidth > 0) {
+                        val offset =
+                            try {
+                                abs(state.requireOffset())
+                            } catch (e: Exception) {
+                                0f
+                            }
+                        offset >= (itemWidth * 0.35f)
+                    } else {
+                        false
+                    }
                 } else {
                     true
                 }
@@ -55,6 +70,7 @@ fun DeeprItemSwipable(
         modifier =
             modifier
                 .fillMaxSize()
+                .onSizeChanged { itemWidth = it.width }
                 .clip(RoundedCornerShape(8.dp)),
         state = dismissState,
         onDismiss = {

--- a/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/home/DeeprItemSwipable.kt
+++ b/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/home/DeeprItemSwipable.kt
@@ -51,7 +51,7 @@ fun DeeprItemSwipable(
                     true
                 }
             },
-            positionalThreshold = { it * 0.7f },
+            positionalThreshold = { it * 0.5f },
         )
     dismissStateHolder.value = dismissState
 

--- a/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/home/DeeprItemSwipable.kt
+++ b/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/home/DeeprItemSwipable.kt
@@ -10,6 +10,8 @@ import androidx.compose.material3.SwipeToDismissBox
 import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -31,15 +33,17 @@ fun DeeprItemSwipable(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
+    val dismissStateHolder = remember { mutableStateOf<androidx.compose.material3.SwipeToDismissBoxState?>(null) }
     val dismissState =
         rememberSwipeToDismissBoxState(
             initialValue = SwipeToDismissBoxValue.Settled,
             confirmValueChange = {
-                val progress = dismissState.progress
+                val progress = dismissStateHolder.value?.progress ?: 0f
                 progress >= 0.5f
             },
             positionalThreshold = { it * 0.5f },
         )
+    dismissStateHolder.value = dismissState
 
     val scope = rememberCoroutineScope()
 

--- a/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/home/DeeprItemSwipable.kt
+++ b/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/home/DeeprItemSwipable.kt
@@ -39,8 +39,14 @@ fun DeeprItemSwipable(
             initialValue = SwipeToDismissBoxValue.Settled,
             confirmValueChange = { newValue ->
                 if (newValue != SwipeToDismissBoxValue.Settled) {
-                    val progress = dismissStateHolder.value?.progress ?: 0f
-                    progress >= 0.7f
+                    val state = dismissStateHolder.value
+                    if (state != null) {
+                        // Reject velocity-based flings: only allow dismiss if the user
+                        // has actually dragged past the positional threshold (70%).
+                        state.targetValue == newValue
+                    } else {
+                        false
+                    }
                 } else {
                     true
                 }

--- a/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/home/DeeprItemSwipable.kt
+++ b/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/home/DeeprItemSwipable.kt
@@ -37,11 +37,15 @@ fun DeeprItemSwipable(
     val dismissState =
         rememberSwipeToDismissBoxState(
             initialValue = SwipeToDismissBoxValue.Settled,
-            confirmValueChange = {
-                val progress = dismissStateHolder.value?.progress ?: 0f
-                progress >= 0.5f
+            confirmValueChange = { newValue ->
+                if (newValue != SwipeToDismissBoxValue.Settled) {
+                    val progress = dismissStateHolder.value?.progress ?: 0f
+                    progress >= 0.7f
+                } else {
+                    true
+                }
             },
-            positionalThreshold = { it * 0.5f },
+            positionalThreshold = { it * 0.7f },
         )
     dismissStateHolder.value = dismissState
 

--- a/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/home/DeeprItemSwipable.kt
+++ b/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/home/DeeprItemSwipable.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.SwipeToDismissBox
-import androidx.compose.material3.SwipeToDismissBoxDefaults
 import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
@@ -35,7 +34,7 @@ fun DeeprItemSwipable(
     val dismissState =
         rememberSwipeToDismissBoxState(
             initialValue = SwipeToDismissBoxValue.Settled,
-            positionalThreshold = SwipeToDismissBoxDefaults.positionalThreshold,
+            positionalThreshold = { it * 0.5f },
         )
 
     val scope = rememberCoroutineScope()

--- a/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/home/DeeprItemSwipable.kt
+++ b/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/home/DeeprItemSwipable.kt
@@ -39,14 +39,8 @@ fun DeeprItemSwipable(
             initialValue = SwipeToDismissBoxValue.Settled,
             confirmValueChange = { newValue ->
                 if (newValue != SwipeToDismissBoxValue.Settled) {
-                    val state = dismissStateHolder.value
-                    if (state != null) {
-                        // Reject velocity-based flings: only allow dismiss if the user
-                        // has actually dragged past the positional threshold (70%).
-                        state.targetValue == newValue
-                    } else {
-                        false
-                    }
+                    val progress = dismissStateHolder.value?.progress ?: 0f
+                    progress >= 0.35f
                 } else {
                     true
                 }

--- a/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/home/DeeprItemSwipable.kt
+++ b/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/home/DeeprItemSwipable.kt
@@ -51,7 +51,7 @@ fun DeeprItemSwipable(
                     true
                 }
             },
-            positionalThreshold = { it * 0.5f },
+            positionalThreshold = { it * 0.35f },
         )
     dismissStateHolder.value = dismissState
 

--- a/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/home/DeeprItemSwipable.kt
+++ b/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/home/DeeprItemSwipable.kt
@@ -10,17 +10,11 @@ import androidx.compose.material3.SwipeToDismissBox
 import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.yogeshpaliyal.deepr.GetLinksAndTags
@@ -29,7 +23,6 @@ import compose.icons.TablerIcons
 import compose.icons.tablericons.Edit
 import compose.icons.tablericons.Trash
 import kotlinx.coroutines.launch
-import kotlin.math.abs
 
 @Composable
 fun DeeprItemSwipable(
@@ -38,34 +31,11 @@ fun DeeprItemSwipable(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
-    var itemWidth by remember { mutableIntStateOf(0) }
-    val dismissStateHolder = remember { mutableStateOf<androidx.compose.material3.SwipeToDismissBoxState?>(null) }
     val dismissState =
         rememberSwipeToDismissBoxState(
             initialValue = SwipeToDismissBoxValue.Settled,
-            confirmValueChange = { newValue ->
-                if (newValue != SwipeToDismissBoxValue.Settled) {
-                    val state = dismissStateHolder.value
-                    if (state != null && itemWidth > 0) {
-                        val offset =
-                            try {
-                                abs(state.requireOffset())
-                            } catch (e: Exception) {
-                                0f
-                            }
-                        // Block accidental micro-flicks (e.g. from vertical scrolling)
-                        // but allow intentional fast flings once they cross 20% of the item.
-                        offset >= (itemWidth * 0.20f)
-                    } else {
-                        false
-                    }
-                } else {
-                    true
-                }
-            },
             positionalThreshold = { it * 0.35f },
         )
-    dismissStateHolder.value = dismissState
 
     val scope = rememberCoroutineScope()
 
@@ -73,9 +43,10 @@ fun DeeprItemSwipable(
         modifier =
             modifier
                 .fillMaxSize()
-                .onSizeChanged { itemWidth = it.width }
                 .clip(RoundedCornerShape(8.dp)),
         state = dismissState,
+        enableDismissFromStartToEnd = true,
+        enableDismissFromEndToStart = true,
         onDismiss = {
             scope.launch {
                 dismissState.reset()

--- a/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/home/DeeprItemSwipable.kt
+++ b/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/home/DeeprItemSwipable.kt
@@ -34,6 +34,10 @@ fun DeeprItemSwipable(
     val dismissState =
         rememberSwipeToDismissBoxState(
             initialValue = SwipeToDismissBoxValue.Settled,
+            confirmValueChange = {
+                val progress = dismissState.progress
+                progress >= 0.5f
+            },
             positionalThreshold = { it * 0.5f },
         )
 


### PR DESCRIPTION
Fixes #290

**Description:**
This PR addresses the issue where the `SwipeToDismissBox` was too sensitive, causing accidental triggers (deletions or edits) during vertical scrolling.

**Changes:**
1.  **Positional Threshold:** Set to `35%` (0.35f) to ensure a deliberate drag distance is required for slow swipes.
2.  **Fling/Velocity Blocker:** Added logic inside `confirmValueChange` that calculates the exact physical pixel `offset` of the swipe against the `itemWidth`. It now requires at least a `20%` physical drag distance to permit a fast fling. This completely eliminates accidental micro-flicks (e.g. 5-15% accidental diagonal movements during vertical scroll) while retaining the fluidity of intentional fast swipes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced swipe-to-dismiss behavior with improved accuracy, preventing unintended dismissals from minor swipe gestures by enforcing a 20% threshold requirement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yogeshpaliyal/Deepr/pull/446?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->