### PR TITLE
feat: add optional app lock via device credentials

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -170,6 +170,7 @@ dependencies {
     implementation(libs.ktor.client.android)
     implementation(libs.androidx.work.runtime.ktx)
     implementation(libs.androidx.documentfile)
+    implementation(libs.androidx.lifecycle.process)
 
     "proImplementation"(platform(libs.firebase.bom))
     "proImplementation"(libs.firebase.analytics)

--- a/app/src/main/java/com/yogeshpaliyal/deepr/DeeprApplication.kt
+++ b/app/src/main/java/com/yogeshpaliyal/deepr/DeeprApplication.kt
@@ -2,6 +2,9 @@ package com.yogeshpaliyal.deepr
 
 import android.app.Application
 import android.util.Log
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
 import app.cash.sqldelight.logs.LogSqliteDriver
@@ -22,6 +25,7 @@ import com.yogeshpaliyal.deepr.preference.AppPreferenceDataStore
 import com.yogeshpaliyal.deepr.preference.PreferenceRepository
 import com.yogeshpaliyal.deepr.review.ReviewManager
 import com.yogeshpaliyal.deepr.review.ReviewManagerFactory
+import com.yogeshpaliyal.deepr.security.AppLockState
 import com.yogeshpaliyal.deepr.server.LocalServerRepository
 import com.yogeshpaliyal.deepr.server.LocalServerRepositoryImpl
 import com.yogeshpaliyal.deepr.server.LocalServerTransferLink
@@ -44,6 +48,16 @@ import org.koin.dsl.module
 class DeeprApplication : Application() {
     override fun onCreate() {
         super.onCreate()
+
+        // Re-lock the app whenever it leaves the foreground, so app-lock (when enabled)
+        // requires re-authentication each time the app is brought back.
+        ProcessLifecycleOwner.get().lifecycle.addObserver(
+            object : DefaultLifecycleObserver {
+                override fun onStop(owner: LifecycleOwner) {
+                    AppLockState.isUnlocked.value = false
+                }
+            },
+        )
 
         val appModule =
             module {

--- a/app/src/main/java/com/yogeshpaliyal/deepr/MainActivity.kt
+++ b/app/src/main/java/com/yogeshpaliyal/deepr/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.yogeshpaliyal.deepr
 
+import android.app.KeyguardManager
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
@@ -7,6 +8,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
@@ -33,6 +35,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
+import androidx.core.content.getSystemService
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.NavEntry
@@ -40,11 +43,13 @@ import androidx.navigation3.runtime.rememberSavedStateNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
 import androidx.navigation3.ui.rememberSceneSetupNavEntryDecorator
 import com.yogeshpaliyal.deepr.preference.PreferenceRepository
+import com.yogeshpaliyal.deepr.security.AppLockState
 import com.yogeshpaliyal.deepr.ui.BaseScreen
 import com.yogeshpaliyal.deepr.ui.LocalNavigator
 import com.yogeshpaliyal.deepr.ui.Screen
 import com.yogeshpaliyal.deepr.ui.TopLevelBackStack
 import com.yogeshpaliyal.deepr.ui.TopLevelRoute
+import com.yogeshpaliyal.deepr.ui.screens.AppLockScreen
 import com.yogeshpaliyal.deepr.ui.screens.Settings
 import com.yogeshpaliyal.deepr.ui.screens.home.Dashboard2
 import com.yogeshpaliyal.deepr.ui.screens.home.TagSelectionScreen
@@ -72,6 +77,32 @@ data class ClipboardLink(
 
 class MainActivity : ComponentActivity() {
     val sharingLink = MutableStateFlow<SharedLink?>(null)
+
+    private val confirmCredentialLauncher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            if (result.resultCode == RESULT_OK) {
+                AppLockState.isUnlocked.value = true
+            }
+        }
+
+    private fun requestDeviceCredentialUnlock() {
+        val keyguardManager = getSystemService<KeyguardManager>()
+        if (keyguardManager?.isDeviceSecure != true) {
+            // No PIN/pattern/biometric configured on this device, nothing to gate against.
+            AppLockState.isUnlocked.value = true
+            return
+        }
+        val intent =
+            keyguardManager.createConfirmDeviceCredentialIntent(
+                getString(R.string.app_lock_prompt_title),
+                getString(R.string.app_lock_prompt_description),
+            )
+        if (intent != null) {
+            confirmCredentialLauncher.launch(intent)
+        } else {
+            AppLockState.isUnlocked.value = true
+        }
+    }
 
     override fun attachBaseContext(newBase: Context?) {
         super.attachBaseContext(
@@ -127,11 +158,26 @@ class MainActivity : ComponentActivity() {
                     "dynamic"
                 }
 
+            val appLockEnabled by viewModel.appLockEnabled.collectAsStateWithLifecycle()
+            val isUnlocked by AppLockState.isUnlocked
+            val isLocked = appLockEnabled && !isUnlocked
+
+            LaunchedEffect(isLocked) {
+                if (isLocked) {
+                    requestDeviceCredentialUnlock()
+                }
+            }
+
             DeeprTheme(themeMode = themeMode, colorTheme = colorTheme) {
                 Surface {
+                    // Dashboard stays composed (preserving its nav back stack) even while
+                    // locked; the lock screen is drawn on top and fully obscures it.
                     val sharedText by sharingLink.collectAsStateWithLifecycle()
                     Dashboard(sharedText = sharedText) {
                         sharingLink.update { null }
+                    }
+                    if (isLocked) {
+                        AppLockScreen(onUnlockClick = ::requestDeviceCredentialUnlock)
                     }
                 }
             }

--- a/app/src/main/java/com/yogeshpaliyal/deepr/preference/AppPreferenceDataStore.kt
+++ b/app/src/main/java/com/yogeshpaliyal/deepr/preference/AppPreferenceDataStore.kt
@@ -43,6 +43,7 @@ class AppPreferenceDataStore(
             booleanPreferencesKey("google_drive_auto_backup_enabled")
         private val CLIPBOARD_LINK_DETECTION_ENABLED =
             booleanPreferencesKey("clipboard_link_detection_enabled")
+        private val APP_LOCK_ENABLED = booleanPreferencesKey("app_lock_enabled")
     }
 
     override val getSortingOrder: Flow<@SortType String> =
@@ -138,6 +139,11 @@ class AppPreferenceDataStore(
     override val getClipboardLinkDetectionEnabled: Flow<Boolean> =
         context.appDataStore.data.map { preferences ->
             preferences[CLIPBOARD_LINK_DETECTION_ENABLED] ?: true // Default to enabled
+        }
+
+    override val getAppLockEnabled: Flow<Boolean> =
+        context.appDataStore.data.map { preferences ->
+            preferences[APP_LOCK_ENABLED] ?: false // Default to disabled
         }
 
     override suspend fun setSortingOrder(order: @SortType String) {
@@ -257,6 +263,12 @@ class AppPreferenceDataStore(
     override suspend fun setClipboardLinkDetectionEnabled(enabled: Boolean) {
         context.appDataStore.edit { prefs ->
             prefs[CLIPBOARD_LINK_DETECTION_ENABLED] = enabled
+        }
+    }
+
+    override suspend fun setAppLockEnabled(enabled: Boolean) {
+        context.appDataStore.edit { prefs ->
+            prefs[APP_LOCK_ENABLED] = enabled
         }
     }
 }

--- a/app/src/main/java/com/yogeshpaliyal/deepr/preference/PreferenceRepository.kt
+++ b/app/src/main/java/com/yogeshpaliyal/deepr/preference/PreferenceRepository.kt
@@ -24,6 +24,7 @@ interface PreferenceRepository {
     val getSilentSaveProfileId: Flow<Long>
     val getGoogleDriveAutoBackupEnabled: Flow<Boolean>
     val getClipboardLinkDetectionEnabled: Flow<Boolean>
+    val getAppLockEnabled: Flow<Boolean>
 
     suspend fun setSortingOrder(order: @SortType String)
 
@@ -64,4 +65,6 @@ interface PreferenceRepository {
     suspend fun setGoogleDriveAutoBackupEnabled(enabled: Boolean)
 
     suspend fun setClipboardLinkDetectionEnabled(enabled: Boolean)
+
+    suspend fun setAppLockEnabled(enabled: Boolean)
 }

--- a/app/src/main/java/com/yogeshpaliyal/deepr/security/AppLockState.kt
+++ b/app/src/main/java/com/yogeshpaliyal/deepr/security/AppLockState.kt
@@ -1,0 +1,13 @@
+package com.yogeshpaliyal.deepr.security
+
+import androidx.compose.runtime.mutableStateOf
+
+/**
+ * Process-scoped unlock flag for the optional app-lock feature. Reset to false whenever the
+ * whole app leaves the foreground (see ProcessLifecycleOwner wiring in DeeprApplication), so
+ * re-authentication is required each time the app is brought back, and naturally starts locked
+ * on a fresh process/cold start.
+ */
+object AppLockState {
+    val isUnlocked = mutableStateOf(false)
+}

--- a/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/AppLockScreen.kt
+++ b/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/AppLockScreen.kt
@@ -1,0 +1,59 @@
+package com.yogeshpaliyal.deepr.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.yogeshpaliyal.deepr.R
+import compose.icons.TablerIcons
+import compose.icons.tablericons.Lock
+
+@Composable
+fun AppLockScreen(
+    onUnlockClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(modifier = modifier.fillMaxSize()) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Icon(
+                imageVector = TablerIcons.Lock,
+                contentDescription = null,
+                modifier = Modifier.padding(bottom = 16.dp),
+                tint = MaterialTheme.colorScheme.primary,
+            )
+            Text(
+                text = stringResource(R.string.app_lock_screen_title),
+                style = MaterialTheme.typography.titleLarge,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                text = stringResource(R.string.app_lock_screen_subtitle),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(top = 8.dp, bottom = 24.dp),
+            )
+            Button(onClick = onUnlockClick) {
+                Text(stringResource(R.string.unlock))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/Settings.kt
+++ b/app/src/main/java/com/yogeshpaliyal/deepr/ui/screens/Settings.kt
@@ -1,6 +1,8 @@
 package com.yogeshpaliyal.deepr.ui.screens
 
+import android.app.KeyguardManager
 import android.content.Intent
+import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -35,6 +37,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import androidx.core.content.getSystemService
 import androidx.core.net.toUri
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
@@ -60,6 +63,7 @@ import compose.icons.tablericons.ExternalLink
 import compose.icons.tablericons.Folders
 import compose.icons.tablericons.InfoCircle
 import compose.icons.tablericons.Language
+import compose.icons.tablericons.Lock
 import compose.icons.tablericons.Moon
 import compose.icons.tablericons.Photo
 import compose.icons.tablericons.Server
@@ -107,6 +111,8 @@ fun SettingsScreen(
     val isThumbnailEnable by viewModel.isThumbnailEnable.collectAsStateWithLifecycle()
     val showOpenCounter by viewModel.showOpenCounter.collectAsStateWithLifecycle()
     val clipboardLinkDetectionEnabled by viewModel.clipboardLinkDetectionEnabled.collectAsStateWithLifecycle()
+    val appLockEnabled by viewModel.appLockEnabled.collectAsStateWithLifecycle()
+    val keyguardManager = remember { context.getSystemService<KeyguardManager>() }
 
     // Collect profiles and silent save profile preference
     val allProfiles by viewModel.allProfiles.collectAsStateWithLifecycle()
@@ -317,6 +323,43 @@ fun SettingsScreen(
                         Switch(
                             checked = clipboardLinkDetectionEnabled,
                             onCheckedChange = { viewModel.setClipboardLinkDetectionEnabled(it) },
+                        )
+                    },
+                )
+            }
+
+            SettingsSection("Security") {
+                SettingsItem(
+                    TablerIcons.Lock,
+                    title = stringResource(R.string.app_lock),
+                    description = stringResource(R.string.app_lock_description),
+                    onClick = {
+                        if (appLockEnabled || keyguardManager?.isDeviceSecure == true) {
+                            viewModel.setAppLockEnabled(!appLockEnabled)
+                        } else {
+                            Toast
+                                .makeText(
+                                    context,
+                                    context.getString(R.string.app_lock_unavailable),
+                                    Toast.LENGTH_LONG,
+                                ).show()
+                        }
+                    },
+                    trailing = {
+                        Switch(
+                            checked = appLockEnabled,
+                            onCheckedChange = { enabled ->
+                                if (!enabled || keyguardManager?.isDeviceSecure == true) {
+                                    viewModel.setAppLockEnabled(enabled)
+                                } else {
+                                    Toast
+                                        .makeText(
+                                            context,
+                                            context.getString(R.string.app_lock_unavailable),
+                                            Toast.LENGTH_LONG,
+                                        ).show()
+                                }
+                            },
                         )
                     },
                 )

--- a/app/src/main/java/com/yogeshpaliyal/deepr/viewmodel/AccountViewModel.kt
+++ b/app/src/main/java/com/yogeshpaliyal/deepr/viewmodel/AccountViewModel.kt
@@ -647,6 +647,17 @@ class AccountViewModel(
         }
     }
 
+    // App lock (device credential) preference methods
+    val appLockEnabled =
+        preferenceRepository.getAppLockEnabled
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+
+    fun setAppLockEnabled(enabled: Boolean) {
+        viewModelScope.launch(Dispatchers.IO) {
+            preferenceRepository.setAppLockEnabled(enabled)
+        }
+    }
+
     // Auto backup preference methods
     val autoBackupEnabled =
         preferenceRepository.getAutoBackupEnabled

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -286,4 +286,14 @@
     <string name="theme_light">Light</string>
     <string name="theme_dark">Dark</string>
     <string name="close">Close</string>
+
+    <!-- App Lock (device credential authentication) -->
+    <string name="app_lock">App Lock</string>
+    <string name="app_lock_description">Require your device PIN, pattern, or biometric to open Deepr</string>
+    <string name="app_lock_unavailable">Set up a device PIN, pattern, or biometric lock in your system settings to use this feature</string>
+    <string name="app_lock_prompt_title">Unlock Deepr</string>
+    <string name="app_lock_prompt_description">Confirm your device credentials to continue</string>
+    <string name="app_lock_screen_title">Deepr is locked</string>
+    <string name="app_lock_screen_subtitle">Unlock with your device credentials to continue</string>
+    <string name="unlock">Unlock</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,7 @@ androidx-compose-material-icons-extended = { module = "androidx.compose.material
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-documentfile = { module = "androidx.documentfile:documentfile", version.ref = "documentfile" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }
+androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "lifecycleRuntimeKtx" }
 compose-qr-code = { module = "com.lightspark:compose-qr-code", version.ref = "composeQrCode" }
 coroutines-extensions = { module = "app.cash.sqldelight:coroutines-extensions", version.ref = "androidDriver" }
 firebase-analytics = { module = "com.google.firebase:firebase-analytics" }


### PR DESCRIPTION
Adds an opt-in Settings toggle that gates app access behind the device's own PIN/pattern/password/biometric (KeyguardManager confirm- credential flow) instead of a custom auth system. Locks on cold start and whenever the app leaves the foreground (via ProcessLifecycleOwner), with a themed lock screen overlaid on top of the dashboard so nav state survives the lock/unlock cycle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional app lock protection using the device’s screen lock credentials.
  * Added an App Lock setting in Settings, available when a secure device lock is configured.
  * Added a lock screen with an unlock action when the app requires authentication.
  * App lock state is reset when the app leaves the foreground.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->